### PR TITLE
Fix Vite configuration for production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN npm run build
 FROM node:18-alpine AS production
 WORKDIR /usr/src/app
 
-# 本番依存のみインストール
+# 本番依存関係とdev依存関係も含めてインストール（サーバーがViteを使用するため）
 COPY package*.json ./
-RUN npm ci --production
+RUN npm ci
 
 # ビルド成果物をコピー
 COPY --from=builder /usr/src/app/dist ./dist

--- a/client/index.html
+++ b/client/index.html
@@ -10,7 +10,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->
-    <script type="text/javascript" src="https://replit.com/public/js/replit-dev-banner.js"></script>
   </body>
 </html>

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,10 +1,13 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const viteLogger = createLogger();
 
@@ -46,7 +49,7 @@ export async function setupVite(app: Express, server: Server) {
 
     try {
       const clientTemplate = path.resolve(
-        import.meta.dirname,
+        __dirname,
         "..",
         "client",
         "index.html",
@@ -68,7 +71,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const distPath = path.resolve(__dirname, "public");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,18 +3,16 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 
 export default defineConfig({
-  plugins: [
-    react(),
-    // Replit依存プラグインを削除しました。
-    ...(process.env.NODE_ENV === "development"
-      ? [
-          // 開発時のみcartographer等を設定する場合はここに
-        ]
-      : []),
-  ],
-  root: path.resolve(__dirname, "client"),
+  plugins: [react()],
+  root: "./client",
+  resolve: {
+    alias: {
+      "@": path.resolve("./client/src"),
+      "@shared": path.resolve("./shared"),
+    },
+  },
   build: {
-    outDir: path.resolve(__dirname, "dist/public"),
+    outDir: "../dist/public",
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
# 問題の原因
1. Viteアプリケーションの仕組み: index.html は、Viteサーバー経由でアクセスされることを前提に設計されています。このHTMLファイルには`<script type="module" src="/src/main.tsx"></script>`という記述があり、これはViteサーバーがTypeScriptファイルをJavaScriptに変換して提供する必要があります。
2. モジュール形式の依存関係: React、TypeScript、その他のモジュールはブラウザが直接理解できない形式で書かれており、Viteやwebpackのようなビルドツールが必要です。

# 解決した主な問題
1. Viteパスエイリアスの未設定: `@`と`@shared`エイリアスを vite.config.ts に追加
2. Docker本番環境の依存関係不足: 本番環境でもViteの依存関係が必要なため、`npm ci`で全依存をインストール
3. Node.js 18のESM互換性: `import.meta.dirname`が未サポートのため、`import.meta.url`と`fileURLToPath`を使用してパス解決を修正
4. ビルド出力パスの修正: vite.config.ts の`outDir`を正しいパスに変更

# 正しいアクセス方法
- 開発環境: `npm run dev`でViteサーバーを起動してアクセス
- 本番環境: Docker経由で起動したサーバー`http://localhost:3000`にアクセス

# 技術的詳細
アプリは現在、Dockerコンテナ内で以下の仕組みで動作しています：

1. ビルド時: ViteがclientフォルダのTypeScript/Reactコードを`dist/public/`にビルド
2. 実行時: Express.jsサーバーが`dist/public/`の静的ファイルを配信
3. 本番モード: `NODE_ENV=production`により、`serveStatic`関数が使用される